### PR TITLE
修复--proxy参数 调用fofa接口网络超时问题

### DIFF
--- a/mod/fofa.py
+++ b/mod/fofa.py
@@ -51,13 +51,13 @@ class Fofa(threading.Thread):
             req = requests.Session()
             req.keep_alive = False
             req.headers = self.headers
-            if Proxys.proxyList:
-                if pyVersion < "3.8":
-                    req.proxies = {'https': '{0}'.format(
-                        random.choice(Proxys.scheme))}
-                else:
-                    req.proxies = {
-                        "https": 'https://{0}'.format(random.choice(Proxys.scheme))}
+#            if Proxys.proxyList:
+#                if pyVersion < "3.8":
+#                    req.proxies = {'https': '{0}'.format(
+#                        random.choice(Proxys.scheme))}
+#                else:
+#                    req.proxies = {
+#                        "https": 'https://{0}'.format(random.choice(Proxys.scheme))}
             req.mount("https://", HTTPAdapter(max_retries=2))
             target = req.get(url, timeout=10)
             lock.acquire()


### PR DESCRIPTION
直接注释了调用fofa接口的代码中设置代理的部分，此部分会导致-i参数配合--proxy参数时报错，且无必要在调用fofa接口时使用代理。